### PR TITLE
Fix ETA parsing for hashcat text status

### DIFF
--- a/HashcatGUI/Services/HashcatService.cs
+++ b/HashcatGUI/Services/HashcatService.cs
@@ -485,7 +485,7 @@ public class HashcatService : IDisposable
     // Regex patterns for parsing hashcat text output - made more flexible
     private static readonly Regex SpeedRegex = new(@"Speed[.#\d\*]*\s*[:\.]+\s*([\d.,]+)\s*([kMGT]?H/s)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex ProgressRegex = new(@"Progress\s*[:\.]+\s*([\d]+)\s*/\s*([\d]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    private static readonly Regex EtaRegex = new(@"Time\.Estimated|ETA\s*[:\.]+\s*(.+?)(?:\s*\(|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex EtaRegex = new(@"(?:Time\.Estimated|ETA)\s*[:\.]+\s*(.+?)(?:\s*\(|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly Regex RecoveredRegex = new(@"Recovered\s*[:\.]+\s*(\d+)\s*/\s*(\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private void OnOutputDataReceived(object sender, DataReceivedEventArgs e)


### PR DESCRIPTION
### Motivation
- Improve ETA extraction from hashcat text output so both `Time.Estimated` and `ETA` style lines reliably capture the timestamp.

### Description
- Update the `EtaRegex` in `HashcatGUI/Services/HashcatService.cs` to `@"(?:Time\.Estimated|ETA)\s*[:\.]+\s*(.+?)(?:\s*\(|$)"` so the alternation is grouped and the timestamp capture works for both variants.

### Testing
- Attempted to run `dotnet build --configuration Release` but the environment lacked the `dotnet` tool, so no build or automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d07f0c1988320bc4c292b5127c501)